### PR TITLE
BLIND, DIMMER & RGBW Fix

### DIFF
--- a/HomeMaticChannel.js
+++ b/HomeMaticChannel.js
@@ -214,9 +214,15 @@ function HomeMaticGenericChannel(log,platform, id ,name, type ,adress,special, c
     var tpos = blind.getCharacteristic(Characteristic.TargetPosition)
     
     .on('get', function(callback) {
-      that.query("LEVEL",function(value){
-       if (callback) callback(null,value*100);
-      });
+	if (that.state["LEVEL"] != undefined ) {
+		callback(null,that.state["LEVEL"]);
+	} else {
+      		that.query("LEVEL",function(value){
+			if (callback) {
+				callback(null,value*100);
+			}
+		});
+	}
     }.bind(this))
     
     .on('set', function(value, callback) {

--- a/HomeMaticChannel.js
+++ b/HomeMaticChannel.js
@@ -196,7 +196,6 @@ function HomeMaticGenericChannel(log,platform, id ,name, type ,adress,special, c
 
     // Window Covering
     case "BLIND":
-    this.usecache = false;	// temporary till cache bug fixed?
     var blind = new Service["WindowCovering"](this.name);
     this.services.push(blind);
 
@@ -758,9 +757,7 @@ HomeMaticGenericChannel.prototype = {
       that.eventupdate = true;
       //var ow = newValue;
       newValue = that.convertValue(dp,newValue);
-      if (tp[1] != 'LEVEL') {
-      	that.cache(dp,newValue);	// bug in caching?
-      }
+      that.cache(dp,newValue);
       that.eventupdate = false;
      } else {
       newValue = 0;

--- a/HomeMaticChannel.js
+++ b/HomeMaticChannel.js
@@ -205,7 +205,7 @@ function HomeMaticGenericChannel(log,platform, id ,name, type ,adress,special, c
       that.query("LEVEL",function(value){
        if (callback) callback(null,value*100);
       });
-    }.bind(this))
+    }.bind(this));
 
     this.currentStateCharacteristic["LEVEL"] = cpos;
     cpos.eventEnabled = true;
@@ -315,7 +315,7 @@ function HomeMaticGenericChannel(log,platform, id ,name, type ,adress,special, c
         that.query("STATE",function(value) {
          if (callback) {callback(null,value);}
         });
-      }.bind(this))
+      }.bind(this));
       this.currentStateCharacteristic["STATE"] = state;
       state.eventEnabled = true;
       this.addValueMapping("STATE",0,0);
@@ -336,7 +336,7 @@ function HomeMaticGenericChannel(log,platform, id ,name, type ,adress,special, c
       that.query("MOTION",function(value){
        if (callback) callback(null,value);
       });
-    }.bind(this))
+    }.bind(this));
 
     this.currentStateCharacteristic["MOTION"] = state;
     state.eventEnabled = true;
@@ -354,7 +354,7 @@ function HomeMaticGenericChannel(log,platform, id ,name, type ,adress,special, c
       that.query("STATE",function(value){
        if (callback) callback(null,value);
       });
-    }.bind(this))
+    }.bind(this));
 
     this.currentStateCharacteristic["STATE"] = state;
     state.eventEnabled = true;
@@ -448,7 +448,7 @@ function HomeMaticGenericChannel(log,platform, id ,name, type ,adress,special, c
       that.query("TEMPERATURE",function(value){
        if (callback) callback(null,value);
       });
-    }.bind(this))
+    }.bind(this));
 
     this.currentStateCharacteristic["TEMPERATURE"] = ctemp;
     ctemp.eventEnabled = true;
@@ -569,7 +569,7 @@ function HomeMaticGenericChannel(log,platform, id ,name, type ,adress,special, c
     thermo.getCharacteristic(Characteristic.TemperatureDisplayUnits)
     .on('get', function(callback) {
       if (callback) callback(null, Characteristic.TemperatureDisplayUnits.CELSIUS);
-    }.bind(this))
+    }.bind(this));
 
     this.cleanVirtualDevice("ACTUAL_TEMPERATURE");
     this.remoteGetValue("CONTROL_MODE");

--- a/HomeMaticChannel.js
+++ b/HomeMaticChannel.js
@@ -669,6 +669,7 @@ HomeMaticGenericChannel.prototype = {
     } else {
       //this.log("Ask CCU");
       this.remoteGetValue(dp, function(value) {
+      if (callback!=undefined){callback(value);}
     });
       if (callback!=undefined){callback(0);}
     }

--- a/HomeMaticChannel.js
+++ b/HomeMaticChannel.js
@@ -203,7 +203,7 @@ function HomeMaticGenericChannel(log,platform, id ,name, type ,adress,special, c
 
     .on('get', function(callback) {
       that.query("LEVEL",function(value){
-       if (callback) callback(null,value);
+       if (callback) callback(null,value*100);
       });
     }.bind(this))
 
@@ -215,7 +215,7 @@ function HomeMaticGenericChannel(log,platform, id ,name, type ,adress,special, c
     
     .on('get', function(callback) {
       that.query("LEVEL",function(value){
-       if (callback) callback(null,value);
+       if (callback) callback(null,value*100);
       });
     }.bind(this))
     
@@ -273,7 +273,7 @@ function HomeMaticGenericChannel(log,platform, id ,name, type ,adress,special, c
       that.query("STATE",function(value){
        callback(null,value);
       });
-      }.bind(this))
+      }.bind(this));
       
       that.currentStateCharacteristic["STATE"] = state;
       state.eventEnabled = true;
@@ -749,7 +749,10 @@ HomeMaticGenericChannel.prototype = {
     //that.platform.getValue(that.adress,dp,function(newValue) {
     
     that.platform.getValue(tp[0],tp[1],function(newValue) {
-      if (newValue != undefined) {
+      if (newValue != undefined) {
+      	if (tp[1] == 'LEVEL') {
+      		newValue = newValue * 100;	// RGBW should be 199? How to differ?
+      	}
       that.eventupdate = true;
       //var ow = newValue;
       newValue = that.convertValue(dp,newValue);

--- a/HomeMaticChannel.js
+++ b/HomeMaticChannel.js
@@ -756,7 +756,9 @@ HomeMaticGenericChannel.prototype = {
       that.eventupdate = true;
       //var ow = newValue;
       newValue = that.convertValue(dp,newValue);
-      that.cache(dp,newValue);
+      if (tp[1] != 'LEVEL') {
+      	that.cache(dp,newValue);	// bug in caching?
+      }
       that.eventupdate = false;
      } else {
       newValue = 0;

--- a/HomeMaticChannel.js
+++ b/HomeMaticChannel.js
@@ -671,7 +671,7 @@ HomeMaticGenericChannel.prototype = {
       this.remoteGetValue(dp, function(value) {
       if (callback!=undefined){callback(value);}
     });
-      if (callback!=undefined){callback(0);}
+      //if (callback!=undefined){callback(0);}
     }
 
   },

--- a/HomeMaticChannel.js
+++ b/HomeMaticChannel.js
@@ -752,7 +752,11 @@ HomeMaticGenericChannel.prototype = {
     that.platform.getValue(tp[0],tp[1],function(newValue) {
       if (newValue != undefined) {
       	if (tp[1] == 'LEVEL') {
-      		newValue = newValue * 100;	// RGBW should be 199? How to differ?
+      		if (that.type == "RGBW_COLOR") {
+      			newValue = newValue * 199
+      		} else {	// BLIND and DIMMER
+      			newValue = newValue * 100;
+      		}
       	}
       that.eventupdate = true;
       //var ow = newValue;
@@ -773,7 +777,11 @@ HomeMaticGenericChannel.prototype = {
 
   event:function(dp,newValue) {
     if (dp=="LEVEL") {
-      newValue = newValue*100;
+    	if (this.type == "RGBW_COLOR") {
+    		newValue = newValue * 199;
+    	} else {	// BLIND and DIMMER
+		newValue = newValue * 100;
+    	}
     }
     this.eventupdate = true;
     if (this.cadress!=undefined) {

--- a/HomeMaticChannel.js
+++ b/HomeMaticChannel.js
@@ -196,6 +196,7 @@ function HomeMaticGenericChannel(log,platform, id ,name, type ,adress,special, c
 
     // Window Covering
     case "BLIND":
+    this.usecache = false;	// temporary till cache bug fixed?
     var blind = new Service["WindowCovering"](this.name);
     this.services.push(blind);
 


### PR DESCRIPTION
newValue kommt bei LEVEL als float zurück.
convertValue würde das aber nicht erkennen, da char.props.format uint8 sagt und somit falsch konvertiert.
Denke das Problem sollte auch den Dimmer betroffen haben.
Für die RGBW müsstest du noch eine weitere Fallunterscheidung einbauen. Da *100 in dem Fall *199 sein müsste.