### PR TITLE
FIX: Wrong Value for Single Press.

### DIFF
--- a/ChannelServices/HomeKitGenericService.js
+++ b/ChannelServices/HomeKitGenericService.js
@@ -666,8 +666,11 @@ HomeKitGenericService.prototype = {
       if (tp[1] == 'PRESS_SHORT') {
         var targetChar = that.currentStateCharacteristic[tp[1]];
         if (targetChar != undefined) {
-          targetChar.setValue(1);
-          setTimeout(function(){targetChar.setValue(0);}, 1000);
+          // The value property of ProgrammableSwitchEvent must be one of the following:
+          // Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS = 0;
+          // Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS = 1;
+          //Characteristic.ProgrammableSwitchEvent.LONG_PRESS = 2;
+          targetChar.setValue(0);
         }
         var chnl = channel.slice(channel.indexOf(":")+1);
         this.channelDatapointEvent(channel,dp,newValue);


### PR DESCRIPTION
ProgrammableSwitchEvent Characteristics können werte für Einfach, Doppel und Lang-Press setzen.
Aktuell wird beim Drücken sofort 1 (Doppelklick) und nach einer Sekunde 0 (Einfachklick) signalisiert.