### PR TITLE
Add support for Homematic IP switches

### DIFF
--- a/ChannelServices/channel_config.json
+++ b/ChannelServices/channel_config.json
@@ -85,6 +85,11 @@
 	},
 
 	{
+		"type": "KEY_TRANSCEIVER",
+		"service": "HomeMaticHomeKitKeyService"
+	},
+
+	{
 	   "type": "TILT_SENSOR",
 	   "service": "HomeMaticHomeKitContactService"
 	},


### PR DESCRIPTION
 which use the type `KEY_TRANSCEIVER` in the channels.

Tested this with the HMIP-WRC2 switch.

This resolves issue #200