### PR TITLE
Fix für ausbleibende Fensterstatus-Atkualisierung, Issue #371

### DIFF
--- a/ChannelServices/HomeMaticHomeKitContactService.js
+++ b/ChannelServices/HomeMaticHomeKitContactService.js
@@ -266,19 +266,19 @@ HomeMaticHomeKitContactService.prototype.processDoorState = function (newValue) 
   }
 }
 
-HomeMaticHomeKitContactService.prototype.processWindowState = function(newValue) {
-  if (this.haz([this.cwindow,this.twindow,this.swindow])) {
-    switch (newValue) {
+HomeMaticHomeKitContactService.prototype.processWindowState = function (newValue) {
+  if (this.haz([this.cwindow, this.twindow, this.swindow])) {
+    switch (newValue) {
       case false :
-      this.cwindow.updateValue(0,null)
-      this.twindow.updateValue(0,null)
-      this.swindow.updateValue(2,null)
-      break;
+        this.cwindow.updateValue(0, null)
+        this.twindow.updateValue(0, null)
+        this.swindow.updateValue(2, null)
+        break
       case true :
-      this.cwindow.updateValue(100,null)
-      this.twindow.updateValue(100,null)
-      this.swindow.updateValue(2,null)
-      break;      
+        this.cwindow.updateValue(100, null)
+        this.twindow.updateValue(100, null)
+        this.swindow.updateValue(2, null)
+        break
     }
   } else {
     this.log.info("Something's missing")
@@ -290,7 +290,7 @@ HomeMaticHomeKitContactService.prototype.datapointEvent = function (dp, newValue
     this.addLogEntry({ status: (newValue === true) ? 1 : 0 })
     if (this.special === 'DOOR') {
       this.processDoorState(newValue)
-    } else if ( this.special == "WINDOW" ) {     
+    } else if (this.special === 'WINDOW') {
       this.processWindowState(newValue)
     } else {
       this.processContactState(newValue)

--- a/ChannelServices/HomeMaticHomeKitContactService.js
+++ b/ChannelServices/HomeMaticHomeKitContactService.js
@@ -96,7 +96,7 @@ HomeMaticHomeKitContactService.prototype.createDeviceService = function (Service
     this.cdoor = door.getCharacteristic(Characteristic.CurrentPosition)
     this.cdoor.on('get', function (callback) {
       that.query('STATE', function (value) {
-        if (callback) callback(null, (value === true) ? 0 : 100)
+        if (callback) callback(null, (value === true) ? 100 : 0)
       })
     })
     this.cdoor.eventEnabled = true
@@ -104,7 +104,7 @@ HomeMaticHomeKitContactService.prototype.createDeviceService = function (Service
     this.tdoor = door.getCharacteristic(Characteristic.TargetPosition)
     this.tdoor.on('get', function (callback) {
       that.query('STATE', function (value) {
-        if (callback) callback(null, (value === true) ? 0 : 100)
+        if (callback) callback(null, (value === true) ? 100 : 0)
       })
     })
 
@@ -254,12 +254,12 @@ HomeMaticHomeKitContactService.prototype.processContactState = function (newValu
 HomeMaticHomeKitContactService.prototype.processDoorState = function (newValue) {
   if (this.haz([this.cdoor, this.tdoor, this.sdoor])) {
     switch (newValue) {
-      case true :
+      case false :
         this.cdoor.updateValue(0, null)
         this.tdoor.updateValue(0, null)
         this.sdoor.updateValue(2, null)
         break
-      case false:
+      case true:
         this.cdoor.updateValue(100, null)
         this.tdoor.updateValue(100, null)
         this.sdoor.updateValue(2, null)

--- a/ChannelServices/HomeMaticHomeKitContactService.js
+++ b/ChannelServices/HomeMaticHomeKitContactService.js
@@ -89,9 +89,7 @@ HomeMaticHomeKitContactService.prototype.createDeviceService = function (Service
     })
 
     this.services.push(window)
-  } else
-
-  if (this.special === 'DOOR') {
+  } else if (this.special === 'DOOR') {
     var door = new Service.Door(this.name)
     this.cdoor = door.getCharacteristic(Characteristic.CurrentPosition)
     this.cdoor.on('get', function (callback) {

--- a/ChannelServices/HomeMaticHomeKitWaterSensorService.js
+++ b/ChannelServices/HomeMaticHomeKitWaterSensorService.js
@@ -1,0 +1,39 @@
+'use strict'
+
+var HomeKitGenericService = require('./HomeKitGenericService.js').HomeKitGenericService
+var util = require('util')
+
+function HomeMaticHomeKitWaterSensorService (log, platform, id, name, type, adress, special, cfg, Service, Characteristic) {
+  HomeMaticHomeKitWaterSensorService.super_.apply(this, arguments)
+}
+
+util.inherits(HomeMaticHomeKitWaterSensorService, HomeKitGenericService)
+
+HomeMaticHomeKitWaterSensorService.prototype.createDeviceService = function (Service, Characteristic) {
+  var that = this
+  var leakSensor = new Service['LeakSensor'](this.name)
+  
+  this.state = leakSensor.getCharacteristic(Characteristic.LeakDetected)
+    .on('get', function (callback) {
+      that.query('ALARMSTATE', function (value) {
+        if (callback) callback(null, value)
+      })
+    })
+  this.currentStateCharacteristic['ALARMSTATE'] = this.state
+  this.state.eventEnabled = true
+  this.services.push(leakSensor)
+  this.platform.registerAdressForEventProcessingAtAccessory(this.adress + '.ALARMSTATE', this)
+}
+
+HomeMaticHomeKitWaterSensorService.prototype.datapointEvent = function (dp, newValue) {
+  let that = this
+  if (this.isDataPointEvent(dp, 'ALARMSTATE')) {
+    this.state.setValue(newValue, null)
+    this.log.debug('Set ALARMSTATE to ', newValue)
+    setTimeout(function () {
+      that.state.setValue(false, null)
+    }, 1000)
+  }
+}
+
+module.exports = HomeMaticHomeKitWaterSensorService

--- a/ChannelServices/HomeMaticHomeKitWaterSensorService.js
+++ b/ChannelServices/HomeMaticHomeKitWaterSensorService.js
@@ -12,7 +12,7 @@ util.inherits(HomeMaticHomeKitWaterSensorService, HomeKitGenericService)
 HomeMaticHomeKitWaterSensorService.prototype.createDeviceService = function (Service, Characteristic) {
   var that = this
   var leakSensor = new Service['LeakSensor'](this.name)
-  
+
   this.state = leakSensor.getCharacteristic(Characteristic.LeakDetected)
     .on('get', function (callback) {
       that.query('ALARMSTATE', function (value) {

--- a/ChannelServices/channel_config.json
+++ b/ChannelServices/channel_config.json
@@ -317,9 +317,16 @@
 	  "type" : "POWERMETER_IGL",
 		"service" : "HomeMaticHomeKitEnergyCounterService"
 	},
-	{ "type":"HM-LC-Ja1PBU-FM:JALOUSIE", 
-	  "service": "HomeMaticHomeKitBlindService"
-	}
+	{
+		"type":"HM-LC-Ja1PBU-FM:JALOUSIE", 
+	  	"service": "HomeMaticHomeKitBlindService"
+	},
+
+
+	{
+        "type": "HmIP-SWD:WATER_DETECTION_TRANSMITTER",
+        "service": "HomeMaticHomeKitWaterSensorService"
+    }
 
 
 


### PR DESCRIPTION
Handling für Fenster neben Türen und Kontakten ergänzt. Funktioniert nun bei mir wieder mit den klassischen Kontakten für Türen und Fenstern, wenn die Kontakte in config.json unter "windows" eingtragen sind.