### PR TITLE
Fix status for blinds

### DIFF
--- a/ChannelServices/HomeMaticHomeKitBlindService.js
+++ b/ChannelServices/HomeMaticHomeKitBlindService.js
@@ -145,7 +145,7 @@ HomeMaticHomeKitBlindService.prototype.processBlindLevel = function (newValue) {
 
 HomeMaticHomeKitBlindService.prototype.endWorking = function () {
   let that = this
-  this.remoteGetValue('4:LEVEL', function (newValue) {
+  this.remoteGetValue('LEVEL', function (newValue) {
     that.processBlindLevel(newValue)
   })
 }


### PR DESCRIPTION
Aktuell werden Änderungen für bei den Rolladen/Jalousien Aktoren  nicht in HomeKit aktualisiert (develop branch).

Siehe auch #300, #311.

Das sollte für Raufstore nun zumindest gefixed sein (im dev branch), getestet mit HM-LC-Bl1-FM.