### PR TITLE
#395 Rollos werden nicht gefunden

### DIFF
--- a/ChannelServices/channel_config.json
+++ b/ChannelServices/channel_config.json
@@ -323,7 +323,10 @@
 	  	"service": "HomeMaticHomeKitBlindService"
 	},
 
-	
+	{
+		"type":"HMW-LC-Bl1-DR:BLIND",
+		"service": "HomeMaticHomeKitBlindService"
+	},
 
 	{
         "type": "HmIP-SWD:WATER_DETECTION_TRANSMITTER",


### PR DESCRIPTION
Unterstützung für HM Rolloaktoren HMW-LC-Bl1-DR hinzugefügt