### PR TITLE
Add a simple Outlet service for Homematic Switches.

### DIFF
--- a/ChannelServices/HomeMaticHomeKitOutletService.js
+++ b/ChannelServices/HomeMaticHomeKitOutletService.js
@@ -25,14 +25,32 @@ class HomeMaticHomeKitOutletService extends HomeKitGenericService {
   }
 
   getState (callback) {
-    this.query('STATE', (value) => {
-      callback(null, JSON.parse(value)) // make sure the value is boolean
-    })
+    callback(null, this.currentState)
   }
 
   setState (value, callback) {
     this.command('set', 'STATE', value)
     callback()
+  }
+
+  get currentState () {
+    if (this._currentState !== undefined) {
+      return this._currentState
+    }
+    // no value found - get remote value
+    this.remoteGetValue('STATE', (value) => {
+      this.currentState = JSON.parse(value) // make sure the value is boolean
+    })
+
+    this.log.warn('got  state: %s for %s', this._currentState, this.address)
+    return this._currentState
+  }
+
+  set currentState (current) {
+    if (this._currentState !== current) {
+      this.onCharacteristic.updateValue(current)
+    }
+    this._currentState = current
   }
 
   event (address, dp, value) {
@@ -41,7 +59,7 @@ class HomeMaticHomeKitOutletService extends HomeKitGenericService {
     }
 
     if (dp === 'STATE') {
-      this.onCharacteristic.updateValue(value)
+      this.currentState = value
     }
   }
 }

--- a/ChannelServices/HomeMaticHomeKitOutletService.js
+++ b/ChannelServices/HomeMaticHomeKitOutletService.js
@@ -42,7 +42,6 @@ class HomeMaticHomeKitOutletService extends HomeKitGenericService {
       this.currentState = JSON.parse(value) // make sure the value is boolean
     })
 
-    this.log.warn('got  state: %s for %s', this._currentState, this.address)
     return this._currentState
   }
 

--- a/ChannelServices/HomeMaticHomeKitOutletService.js
+++ b/ChannelServices/HomeMaticHomeKitOutletService.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const HomeKitGenericService = require('./HomeKitGenericService.js')
+  .HomeKitGenericService
+
+class HomeMaticHomeKitOutletService extends HomeKitGenericService {
+  createDeviceService (Service, Characteristic) {
+    this.ignoreWorking = true
+    this.address = this.adress // fix spelling
+
+    var service = new Service.Outlet(this.name)
+    this.onCharacteristic = service.getCharacteristic(Characteristic.On)
+    this.onCharacteristic
+      .on('get', this.getState.bind(this))
+      .on('set', this.setState.bind(this))
+
+    // Set outlet in use to return always true
+    service.getCharacteristic(Characteristic.OutletInUse)
+      .on('get', (callback) => {
+        callback(null, 1)
+      })
+
+    this.log.debug('Creating new Outlet service for %s: %s, : %s', this.name, this.deviceAdress, this.address)
+    this.services.push(service)
+  }
+
+  getState (callback) {
+    this.query('STATE', (value) => {
+      callback(null, JSON.parse(value)) // make sure the value is boolean
+    })
+  }
+
+  setState (value, callback) {
+    this.command('set', 'STATE', value)
+    callback()
+  }
+
+  event (address, dp, value) {
+    if (this.address !== address) {
+      return // skip not related events...
+    }
+
+    if (dp === 'STATE') {
+      this.onCharacteristic.updateValue(value)
+    }
+  }
+}
+
+module.exports = HomeMaticHomeKitOutletService

--- a/ChannelServices/channel_config.json
+++ b/ChannelServices/channel_config.json
@@ -51,7 +51,7 @@
 
 	{
 	   "type": "SWITCH",
-	   "service": "HomeMaticHomeKitSwitchService"
+	   "service": "HomeMaticHomeKitOutletService"
 	},
 
 
@@ -62,8 +62,14 @@
 
 	{
 	   "type": "HM-LC-Sw1-FM:SWITCH",
-	   "service": "HomeMaticHomeKitSwitchService"
+	   "service": "HomeMaticHomeKitOutletService"
 	},
+
+	{
+	   "type": "HM-LC-Sw1-Pl:SWITCH",
+	   "service": "HomeMaticHomeKitOutletService"
+	},
+
 
 	{
 	   "type": "DIMMER",


### PR DESCRIPTION
Hallo,

dieser pull request dient eher als Anregung. 

Ich hab mir eine simple `HomeMaticHomeKitOutletService` Klasse angelegt, 
da bei mir aktuell die Switches im develop branch nicht funktioniert haben (ich habe hauptsächlich `HM-LC-Sw4-DR`). 
Mir war bewusst, dass ich den Typ, in HomeKit danach händisch auf den jeweiligen Typ (Lüfter/Licht/Steckdose) einmalig konfigurieren muss, dafür spiegelt das meines Erachtens eher den Status von Homematic wieder.

Um die restlichen "special Features" wie "PROGRAM" "VALVE" habe ich mich nicht gekümmert, 
daher dient das eher als einfaches Beispiel falls jemand die selben Probleme hat wie ich. 

Würde es nicht generell Sinn machen, für diese Features eigenen Klassen zu erstellen um die Komplexität geringer zu halten?

In weitere Folge dachte ich mir, wäre es super, wenn mann in der Config Adressen an Services binden könnte, z.b.:
```
"services": [
  {
    "address": "BidCos-RF.KEQXXXXXXX:4",
    "service": "HomeMaticHomeKitValveService"
  } ]
```





 