### PR TITLE
Make bind_ip config independent of local_ip

### DIFF
--- a/HomeMaticRPC.js
+++ b/HomeMaticRPC.js
@@ -84,10 +84,10 @@ var HomeMaticRPC = function (log, ccuip, port, system, platform) {
 HomeMaticRPC.prototype.init = function () {
   var that = this
 
-  var bind_ip = this.platform.config.bind_ip
-  if (bind_ip === undefined) {
-    bind_ip = this.getIPAddress()
-    if (bind_ip === '0.0.0.0') {
+  var bindIP = this.platform.config.bind_ip
+  if (bindIP === undefined) {
+    bindIP = this.getIPAddress()
+    if (bindIP === '0.0.0.0') {
       that.log('Can not fetch IP')
       return
     }
@@ -95,11 +95,11 @@ HomeMaticRPC.prototype.init = function () {
 
   var ip = this.platform.config.local_ip
   if (ip === undefined) {
-    ip = bind_ip
+    ip = bindIP
   }
 
   this.localIP = ip
-  this.bindIP = bind_ip
+  this.bindIP = bindIP
 
   this.log.info('local ip used : %s. you may change that with local_ip parameter in config', ip)
 

--- a/HomeMaticRPC.js
+++ b/HomeMaticRPC.js
@@ -15,6 +15,7 @@ var HomeMaticRPC = function (log, ccuip, port, system, platform) {
   this.client = undefined
   this.stopping = false
   this.localIP = undefined
+  this.bindIP = undefined
   this.listeningPort = port
   this.lastMessage = 0
   this.watchDogTimer = undefined
@@ -83,16 +84,22 @@ var HomeMaticRPC = function (log, ccuip, port, system, platform) {
 HomeMaticRPC.prototype.init = function () {
   var that = this
 
-  var ip = this.platform.config.local_ip
-  if (ip === undefined) {
-    ip = this.getIPAddress()
-    if (ip === '0.0.0.0') {
+  var bind_ip = this.platform.config.bind_ip
+  if (bind_ip === undefined) {
+    bind_ip = this.getIPAddress()
+    if (bind_ip === '0.0.0.0') {
       that.log('Can not fetch IP')
       return
     }
   }
 
+  var ip = this.platform.config.local_ip
+  if (ip === undefined) {
+    ip = bind_ip
+  }
+
   this.localIP = ip
+  this.bindIP = bind_ip
 
   this.log.info('local ip used : %s. you may change that with local_ip parameter in config', ip)
 
@@ -100,7 +107,7 @@ HomeMaticRPC.prototype.init = function () {
     if (error === null) {
       if (inUse === false) {
         that.server = that.rpc.createServer({
-          host: that.localIP,
+          host: that.bindIP,
           port: that.listeningPort
         })
 


### PR DESCRIPTION
Backwards compatibility note:
Defaults to previous behaviour if bind_ip and local_ip not specified. If
bind_ip is specified, local_ip defaults to the bind_ip.
However, if local_ip is specified, but bind_ip is not, binding is done
against the first discovered IP address.

Fixes #500.