### PR TITLE
Added port setting to support latest OCCU version

### DIFF
--- a/HomeMaticRegaRequest.js
+++ b/HomeMaticRegaRequest.js
@@ -2,9 +2,10 @@
 
 var http = require('http')
 
-function HomeMaticRegaRequest (log, ccuip) {
+function HomeMaticRegaRequest (log, ccuip, ccuPort) {
   this.log = log
   this.ccuIP = ccuip
+  this.ccuPort = ccuPort
   this.timeout = 120
 }
 
@@ -19,7 +20,7 @@ HomeMaticRegaRequest.prototype = {
 
     var postOptions = {
       host: this.ccuIP,
-      port: '8181',
+      port: this.ccuPort.toString(),
       path: '/tclrega.exe',
       method: 'POST',
       headers: {

--- a/HomeMaticRegaRequestTestDriver.js
+++ b/HomeMaticRegaRequestTestDriver.js
@@ -1,8 +1,9 @@
 var isInTest = typeof global.it === 'function'
 
-function HomeMaticRegaRequestTestDriver (log, ccuip) {
+function HomeMaticRegaRequestTestDriver (log, ccuip, ccuPort) {
   this.log = log
   this.ccuIP = ccuip
+  this.ccuPort = ccuPort
   this.timeout = 120
   this.data = 0
   if (!isInTest) {

--- a/config.schema.json
+++ b/config.schema.json
@@ -18,6 +18,13 @@
                 "type": "string",
                 "description": "The IP Adress of your CCU"
             },
+            "ccu_port": {
+                "title": "CCU Port",
+                "type": "number",
+                "description": "The Port of your CCU where the REGA web proxy is listening to",
+                "default": 8181,
+                "required": true
+            },
             "subsection": {
                 "title": "Subsection",
                 "type": "string",

--- a/config.schema.json
+++ b/config.schema.json
@@ -22,8 +22,7 @@
                 "title": "CCU Port",
                 "type": "number",
                 "description": "The Port of your CCU where the REGA web proxy is listening to",
-                "default": 8181,
-                "required": true
+                "default": 8181
             },
             "subsection": {
                 "title": "Subsection",

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ function HomeMaticPlatform (log, config, api) {
   this.localPath = _homebridge.user.storagePath()
   this.localHomematicConfig = path.join(this.localPath, 'homematic_config.json')
   this.ccuIP = config.ccu_ip
+  this.ccuPort = config.ccu_port || 8181
   this.cache = new HomeMaticCacheManager(log)
   if (api) {
     this.api = api
@@ -56,7 +57,7 @@ function HomeMaticPlatform (log, config, api) {
     this.log.info('Homematic is a registered trademark of the EQ-3 AG')
     this.log.info('Please report any issues to https://github.com/thkl/homebridge-homematic/issues')
     this.log.info('running in production mode')
-    this.log.info('will connect to your ccu at %s', this.ccuIP)
+    this.log.info('will connect to your ccu at %s:%d', this.ccuIP, this.ccuPort)
     this.log.warn('IMPORTANT !! Starting this version, your homematic custom configuration is located in %s', this.localHomematicConfig)
   }
 
@@ -595,10 +596,10 @@ HomeMaticPlatform.prototype.setValue = function (intf, channel, datapoint, value
 HomeMaticPlatform.prototype.createRegaRequest = function (testreturn) {
   var rega
   if (isInTest) {
-    rega = new HomeMaticRegaRequestTestDriver(this.log, this.ccuIP)
+    rega = new HomeMaticRegaRequestTestDriver(this.log, this.ccuIP, this.ccuPort)
     rega.platform = this
   } else {
-    rega = new HomeMaticRegaRequest(this.log, this.ccuIP)
+    rega = new HomeMaticRegaRequest(this.log, this.ccuIP, this.ccuPort)
   }
   return rega
 }

--- a/util/fetchdevice.js
+++ b/util/fetchdevice.js
@@ -12,6 +12,7 @@ program
   .usage('[options]')
   .option('-A, --address [type]', 'set device address to fetch')
   .option('-C, --ccuip [type]', 'set ccuip ')
+  .option('-P, --ccuport [type]', 'set ccuport ')
   .parse(process.argv)
 
 console.info('')
@@ -31,6 +32,11 @@ if (typeof program.address === 'undefined') {
   process.exit(1)
 }
 
+if (typeof program.ccuport === 'undefined') {
+  console.warn('no device port given. Using 8181 by default.  --help for additional information')
+  program.ccuport = '8181';
+}
+
 let name = 'TA1'
 var script = 'string sDeviceId;string sChannelId;boolean df = true;'
 script = script + 'integer zl = 1000;integer czl=0;'
@@ -47,9 +53,9 @@ script = script + "Write('],\"subsection\":[1000]}');"
 
 script = script.replace('%s', program.address)
 
-console.info('Query CCU at %s', program.ccuip)
+console.info('Query CCU at %s:%s', program.ccuip, program.ccuport)
 
-let request = new HomeMaticRegaRequest(log, program.ccuip)
+let request = new HomeMaticRegaRequest(log, program.ccuip, program.ccuport)
 request.script(script, data => {
   // parse This
   console.info('Resonse from ccu is %s bytes', data.length)


### PR DESCRIPTION
As the port of the REGA web listener has changed to 8183 by default (at least in the OCCU), I've introduced a new configuration option. This prevents the manual adjustments in the `HomeMaticRegaRequest` for folks using affected (O)CCU firmwares.

> [HMCCU2-1452] Port 8182 des Web-Proxies nach 8183 geändert. Port 8182 wird zur Ansteuerung
> der INFO-LED bei Service-Meldungen benutzt.
* https://www.eq-3.de/downloads/software/HM-CCU2-Firmware_Updates/HM-CCU-2.49.18/HM-CCU2-Changelog.2.49.18.pdf
* https://github.com/eq-3/occu/blob/master/arm-gnueabihf/packages-eQ-3/WebUI/etc/rega.conf 

I've implemented the new setting as an optional setting which defaults to 8181 so there won't be a breaking change to existing installations / confugrations. 

Feel free to merge this change, if you want to add the setting to your next release. 

Thanks for the great work on this.