### PR TITLE
Fix humidity warning

### DIFF
--- a/ChannelServices/HomeMaticHomeKitThermostatServiceIP.js
+++ b/ChannelServices/HomeMaticHomeKitThermostatServiceIP.js
@@ -74,7 +74,9 @@ HomeMaticHomeKitIPThermostatService.prototype.createDeviceService = function (Se
   this.cchum = thermo.getCharacteristic(Characteristic.CurrentRelativeHumidity)
     .on('get', function (callback) {
       this.remoteGetValue('HUMIDITY', function (value) {
-        if (callback) callback(null, value)
+        let newValue = 0
+        if (value !== '' ) newValue = value
+        if (callback) callback(null, newValue)
       })
     }.bind(this))
 
@@ -113,8 +115,10 @@ HomeMaticHomeKitIPThermostatService.prototype.createDeviceService = function (Se
 HomeMaticHomeKitIPThermostatService.prototype.queryData = function () {
   var that = this
   this.query('HUMIDITY', function (value) {
-    that.cchum.updateValue(parseFloat(value), null)
-    that.addLogEntry({ humidity: parseFloat(value) })
+    let newHumidity = 0
+    if (value !== '') newHumidity = value
+    that.cchum.updateValue(newHumidity, null)
+    that.addLogEntry({ humidity: newHumidity })
   })
 
   this.query('ACTUAL_TEMPERATURE', function (value) {
@@ -137,8 +141,10 @@ HomeMaticHomeKitIPThermostatService.prototype.datapointEvent = function (dp, new
   }
 
   if (this.isDataPointEvent(dp, 'HUMIDITY')) {
-    this.cchum.updateValue(parseFloat(newValue), null)
-    this.addLogEntry({ humidity: parseFloat(newValue) })
+    let newHumidity = 0
+    if (newValue !== '') newHumidity = newValue
+    this.cchum.updateValue(newHumidity, null)
+    this.addLogEntry({ humidity: newHumidity })
   }
 
   if (this.isDataPointEvent(dp, 'SET_POINT_TEMPERATURE')) {

--- a/ChannelServices/HomeMaticHomeKitThermostatServiceIP.js
+++ b/ChannelServices/HomeMaticHomeKitThermostatServiceIP.js
@@ -116,7 +116,7 @@ HomeMaticHomeKitIPThermostatService.prototype.queryData = function () {
   var that = this
   this.query('HUMIDITY', function (value) {
     let newHumidity = 0
-    if (value !== '') newHumidity = value
+    if (value !== '') newHumidity = parseFloat(value)
     that.cchum.updateValue(newHumidity, null)
     that.addLogEntry({ humidity: newHumidity })
   })
@@ -142,7 +142,7 @@ HomeMaticHomeKitIPThermostatService.prototype.datapointEvent = function (dp, new
 
   if (this.isDataPointEvent(dp, 'HUMIDITY')) {
     let newHumidity = 0
-    if (newValue !== '') newHumidity = newValue
+    if (newValue !== '') newHumidity = parseFloat(newValue)
     this.cchum.updateValue(newHumidity, null)
     this.addLogEntry({ humidity: newHumidity })
   }


### PR DESCRIPTION
HM-IP-eTRV2 is detected as ThermostatServiceIP, however it does not have a humidity value.
This causes some unnecessary warnings in the logs, which this change fixes.